### PR TITLE
Omit default Language

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,6 @@ Description: Dataset with strategic information about COVID-19 in Brazil.
     Sistema Unico de Saude - SUS.
 License: MIT + file LICENSE
 Encoding: UTF-8
-Language: English
 LazyData: true
 LazyDataCompression: xz
 Depends: R (>= 3.5.0)


### PR DESCRIPTION
https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file

WRE mentions `Language:` should only be used if documentation is _not_ in English. The entry should also be an ISO 639 code (like `en`), not the full language name.